### PR TITLE
log_backend_adsp: Move adsp logging from minimal log

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -48,11 +48,12 @@ if(NOT CONFIG_LOG_MINIMAL)
     CONFIG_LOG_MIPI_SYST_ENABLE
     log_output_syst.c
   )
+
+  zephyr_sources_ifdef(
+    CONFIG_LOG_BACKEND_ADSP
+    log_backend_adsp.c
+  )
 else()
   zephyr_sources(log_minimal.c)
 endif()
 
-zephyr_sources_ifdef(
-  CONFIG_LOG_BACKEND_ADSP
-  log_backend_adsp.c
-)


### PR DESCRIPTION
This patch fixes the linker error while building test/kernel since ADSP
backend logging doesn't support minial log config.

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>