### PR TITLE
test: intel_apl_adsp: Disable default test logging config

### DIFF
--- a/soc/xtensa/intel_apl_adsp/Kconfig.defconfig
+++ b/soc/xtensa/intel_apl_adsp/Kconfig.defconfig
@@ -49,4 +49,12 @@ config LOG_BACKEND_ADSP_RINGBUF_SIZE
 
 endif # LOG
 
+if TEST
+
+# To prevent test uses TEST_LOGGING_MINIMAL
+config TEST_LOGGING_DEFAULTS
+	default n
+
+endif # TEST
+
 endif


### PR DESCRIPTION
The test framework uses default test logging which enables
TEST_LOGGING_MINIMAL but adsp backend logging doesn't support it

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>