### PR TITLE
soc: intel_apl_adsp: setup host windows and send fw ready msg

### DIFF
--- a/soc/xtensa/intel_apl_adsp/CMakeLists.txt
+++ b/soc/xtensa/intel_apl_adsp/CMakeLists.txt
@@ -2,5 +2,6 @@
 
 zephyr_library()
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
+zephyr_library_sources(adsp.c)
 zephyr_library_sources(soc.c)
 zephyr_library_sources(main_entry.S)

--- a/soc/xtensa/intel_apl_adsp/adsp.c
+++ b/soc/xtensa/intel_apl_adsp/adsp.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <device.h>
+#include <init.h>
+
+#include <platform/ipc.h>
+#include <platform/mailbox.h>
+#include <platform/shim.h>
+#include <platform/string.h>
+
+#include "soc.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(soc_adsp, CONFIG_SOC_LOG_LEVEL);
+
+static const struct adsp_ipc_fw_ready fw_ready_apl
+	__attribute__((section(".fw_ready"))) __attribute__((used)) = {
+	.hdr = {
+		.cmd = ADSP_IPC_FW_READY,
+		.size = sizeof(struct adsp_ipc_fw_ready),
+	},
+	.version = {
+		.hdr.size = sizeof(struct adsp_ipc_fw_version),
+		.micro = 0,
+		.minor = 1,
+		.major = 0,
+
+		.build = 0,
+		.date = __DATE__,
+		.time = __TIME__,
+
+		.tag = "zephyr",
+		.abi_version = 0,
+	},
+	.flags = 0,
+};
+
+#define NUM_WINDOWS			7
+
+static const struct adsp_ipc_window sram_window = {
+	.ext_hdr = {
+		.hdr.cmd = ADSP_IPC_FW_READY,
+		.hdr.size = sizeof(struct adsp_ipc_window) +
+			    sizeof(struct adsp_ipc_window_elem) * NUM_WINDOWS,
+		.type = ADSP_IPC_EXT_WINDOW,
+	},
+	.num_windows = NUM_WINDOWS,
+	.window = {
+		{
+			.type   = ADSP_IPC_REGION_REGS,
+			.id     = 0,	/* map to host window 0 */
+			.flags  = 0,
+			.size   = MAILBOX_SW_REG_SIZE,
+			.offset = 0,
+		},
+		{
+			.type   = ADSP_IPC_REGION_UPBOX,
+			.id     = 0,	/* map to host window 0 */
+			.flags  = 0,
+			.size   = MAILBOX_DSPBOX_SIZE,
+			.offset = MAILBOX_SW_REG_SIZE,
+		},
+		{
+			.type   = ADSP_IPC_REGION_DOWNBOX,
+			.id     = 1,	/* map to host window 1 */
+			.flags  = 0,
+			.size   = MAILBOX_HOSTBOX_SIZE,
+			.offset = 0,
+		},
+		{
+			.type   = ADSP_IPC_REGION_DEBUG,
+			.id     = 2,	/* map to host window 2 */
+			.flags  = 0,
+			.size   = MAILBOX_EXCEPTION_SIZE + MAILBOX_DEBUG_SIZE,
+			.offset = 0,
+		},
+		{
+			.type   = ADSP_IPC_REGION_EXCEPTION,
+			.id     = 2,	/* map to host window 2 */
+			.flags  = 0,
+			.size   = MAILBOX_EXCEPTION_SIZE,
+			.offset = MAILBOX_EXCEPTION_OFFSET,
+		},
+		{
+			.type   = ADSP_IPC_REGION_STREAM,
+			.id     = 2,	/* map to host window 2 */
+			.flags  = 0,
+			.size   = MAILBOX_STREAM_SIZE,
+			.offset = MAILBOX_STREAM_OFFSET,
+		},
+		{
+			.type   = ADSP_IPC_REGION_TRACE,
+			.id     = 3,	/* map to host window 3 */
+			.flags  = 0,
+			.size   = MAILBOX_TRACE_SIZE,
+			.offset = 0,
+		},
+	},
+};
+
+static void clk_and_pm_init()
+{
+	/* Setup clocks and power management */
+	shim_write(SHIM_CLKCTL,
+		   SHIM_CLKCTL_HDCS_PLL | /* HP domain clocked by PLL */
+		   SHIM_CLKCTL_LDCS_PLL | /* LP domain clocked by PLL */
+		   SHIM_CLKCTL_DPCS_DIV1(0) | /* Core 0 clk not divided */
+		   SHIM_CLKCTL_DPCS_DIV1(1) | /* Core 1 clk not divided */
+		   SHIM_CLKCTL_HPMPCS_DIV2 | /* HP mem clock div by 2 */
+		   SHIM_CLKCTL_LPMPCS_DIV4 | /* LP mem clock div by 4 */
+		   SHIM_CLKCTL_TCPAPLLS_DIS |
+		   SHIM_CLKCTL_TCPLCG_DIS(0) | SHIM_CLKCTL_TCPLCG_DIS(1));
+
+	shim_write(SHIM_LPSCTL, shim_read(SHIM_LPSCTL));
+}
+
+/*
+ * Sets up the host windows so that the host can see the memory
+ * content on the DSP SRAM.
+ */
+static void prepare_host_windows()
+{
+	/* window0, for fw status & outbox/uplink mbox */
+	sys_write32((HP_SRAM_WIN0_SIZE | 0x7), DMWLO(0));
+	sys_write32((HP_SRAM_WIN0_BASE | DMWBA_READONLY | DMWBA_ENABLE),
+		    DMWBA(0));
+	memset((void *)(HP_SRAM_WIN0_BASE + SRAM_REG_FW_END), 0,
+	      HP_SRAM_WIN0_SIZE - SRAM_REG_FW_END);
+	SOC_DCACHE_FLUSH((void *)(HP_SRAM_WIN0_BASE + SRAM_REG_FW_END),
+			 HP_SRAM_WIN0_SIZE - SRAM_REG_FW_END);
+
+	/* window1, for inbox/downlink mbox */
+	sys_write32((HP_SRAM_WIN1_SIZE | 0x7), DMWLO(1));
+	sys_write32((HP_SRAM_WIN1_BASE | DMWBA_ENABLE), DMWBA(1));
+	memset((void *)HP_SRAM_WIN1_BASE, 0, HP_SRAM_WIN1_SIZE);
+	SOC_DCACHE_FLUSH((void *)HP_SRAM_WIN1_BASE, HP_SRAM_WIN1_SIZE);
+
+	/* window2, for debug */
+	sys_write32((HP_SRAM_WIN2_SIZE | 0x7), DMWLO(2));
+	sys_write32((HP_SRAM_WIN2_BASE | DMWBA_ENABLE), DMWBA(2));
+	memset((void *)HP_SRAM_WIN2_BASE, 0, HP_SRAM_WIN2_SIZE);
+	SOC_DCACHE_FLUSH((void *)HP_SRAM_WIN2_BASE, HP_SRAM_WIN2_SIZE);
+
+	/* window3, for trace
+	 * zeroed by trace initialization
+	 */
+	sys_write32((HP_SRAM_WIN3_SIZE | 0x7), DMWLO(3));
+	sys_write32((HP_SRAM_WIN3_BASE | DMWBA_READONLY | DMWBA_ENABLE),
+		    DMWBA(3));
+	memset((void *)HP_SRAM_WIN3_BASE, 0, HP_SRAM_WIN3_SIZE);
+	SOC_DCACHE_FLUSH((void *)HP_SRAM_WIN3_BASE, HP_SRAM_WIN3_SIZE);
+}
+
+static inline
+void mailbox_dspbox_write(size_t offset, const void *src, size_t bytes)
+{
+	memcpy_s((void *)(MAILBOX_DSPBOX_BASE + offset),
+			  MAILBOX_DSPBOX_SIZE - offset, src, bytes);
+	SOC_DCACHE_FLUSH((void *)(MAILBOX_DSPBOX_BASE + offset), bytes);
+}
+
+/*
+ * Sends the firmware ready message so the firmware loader can
+ * map the host windows.
+ */
+static void send_fw_ready()
+{
+	mailbox_dspbox_write(0, &fw_ready_apl, sizeof(fw_ready_apl));
+	mailbox_dspbox_write(sizeof(fw_ready_apl), &sram_window,
+			     sram_window.ext_hdr.hdr.size);
+
+	ipc_write(IPC_DIPCIE, (0x80000 >> 12));
+	ipc_write(IPC_DIPCI, (0x80000000 | ADSP_IPC_FW_READY));
+}
+
+static int adsp_init(struct device *dev)
+{
+	clk_and_pm_init();
+
+	prepare_host_windows();
+
+	send_fw_ready();
+
+	return 0;
+}
+
+SYS_INIT(adsp_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/xtensa/intel_apl_adsp/include/platform/ipc.h
+++ b/soc/xtensa/intel_apl_adsp/include/platform/ipc.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __INCLUDE_PLATFORM_IPC_H__
+#define __INCLUDE_PLATFORM_IPC_H__
+
+/** Shift-left bits to extract the global cmd type */
+#define ADSP_GLB_TYPE_SHIFT			28
+#define ADSP_GLB_TYPE_MASK			(0xf << ADSP_GLB_TYPE_SHIFT)
+#define ADSP_GLB_TYPE(x)			((x) << ADSP_GLB_TYPE_SHIFT)
+
+/** Shift-left bits to extract the command type */
+#define ADSP_CMD_TYPE_SHIFT			16
+#define ADSP_CMD_TYPE_MASK			(0xfff << ADSP_CMD_TYPE_SHIFT)
+#define ADSP_CMD_TYPE(x)			((x) << ADSP_CMD_TYPE_SHIFT)
+
+#define ADSP_IPC_FW_READY			ADSP_GLB_TYPE(0x7U)
+
+/* extended data types that can be appended onto end of adsp_ipc_fw_ready */
+enum adsp_ipc_ext_data {
+	ADSP_IPC_EXT_DMA_BUFFER = 0,
+	ADSP_IPC_EXT_WINDOW,
+};
+
+enum adsp_ipc_region {
+	ADSP_IPC_REGION_DOWNBOX  = 0,
+	ADSP_IPC_REGION_UPBOX,
+	ADSP_IPC_REGION_TRACE,
+	ADSP_IPC_REGION_DEBUG,
+	ADSP_IPC_REGION_STREAM,
+	ADSP_IPC_REGION_REGS,
+	ADSP_IPC_REGION_EXCEPTION,
+};
+
+/**
+ * Structure Header - Header for all IPC structures except command structs.
+ * The size can be greater than the structure size and that means there is
+ * extended bespoke data beyond the end of the structure including variable
+ * arrays.
+ */
+struct adsp_ipc_hdr {
+	uint32_t size;			/**< size of structure */
+} __attribute__((packed));
+
+/**
+ * Command Header - Header for all IPC commands. Identifies IPC message.
+ * The size can be greater than the structure size and that means there is
+ * extended bespoke data beyond the end of the structure including variable
+ * arrays.
+ */
+struct adsp_ipc_cmd_hdr {
+	uint32_t size;			/**< size of structure */
+	uint32_t cmd;			/**< command */
+} __attribute__((packed));
+
+/* FW version */
+struct adsp_ipc_fw_version {
+	struct adsp_ipc_hdr hdr;
+	uint16_t major;
+	uint16_t minor;
+	uint16_t micro;
+	uint16_t build;
+	uint8_t date[12];
+	uint8_t time[10];
+	uint8_t tag[6];
+	uint32_t abi_version;
+
+	/* reserved for future use */
+	uint32_t reserved[4];
+} __attribute__((packed));
+
+/* FW ready Message - sent by firmware when boot has completed */
+struct adsp_ipc_fw_ready {
+	struct adsp_ipc_cmd_hdr hdr;
+	uint32_t dspbox_offset;		/* dsp initiated IPC mailbox */
+	uint32_t hostbox_offset;	/* host initiated IPC mailbox */
+	uint32_t dspbox_size;
+	uint32_t hostbox_size;
+	struct adsp_ipc_fw_version version;
+
+	/* Miscellaneous flags */
+	uint64_t flags;
+
+	/* reserved for future use */
+	uint32_t reserved[4];
+} __attribute__((packed));
+
+struct adsp_ipc_ext_data_hdr {
+	struct adsp_ipc_cmd_hdr hdr;
+	uint32_t type;			/* ADSP_IPC_EXT_ */
+} __attribute__((packed));
+
+struct adsp_ipc_window_elem {
+	struct adsp_ipc_hdr hdr;
+	uint32_t type;			/* ADSP_IPC_REGION_ */
+	uint32_t id;			/* platform specific */
+	uint32_t flags;			/**< R, W, RW, etc */
+	uint32_t size;			/* size of region in bytes */
+
+	/* offset in window region as windows can be partitioned */
+	uint32_t offset;
+} __attribute__((packed));
+
+/* extended data memory windows for IPC, trace and debug */
+struct adsp_ipc_window {
+	struct adsp_ipc_ext_data_hdr ext_hdr;
+	uint32_t num_windows;
+	struct adsp_ipc_window_elem window[];
+} __attribute__((packed));
+
+#endif /* __INCLUDE_PLATFORM_IPC_H__ */

--- a/soc/xtensa/intel_apl_adsp/include/platform/string.h
+++ b/soc/xtensa/intel_apl_adsp/include/platform/string.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __INCLUDE_PLATFORM_STRING_H__
+#define __INCLUDE_PLATFORM_STRING_H__
+
+static inline int memcpy_s(void *dest, size_t dest_size,
+			   const void *src, size_t src_size)
+{
+	if (!dest || !src) {
+		return -EINVAL;
+	}
+
+	if (((char *)dest + dest_size >= (char *)src &&
+	     (char *)dest + dest_size <= (char *)src + src_size) ||
+		((char *)src + src_size >= (char *)dest &&
+		 (char *)src + src_size <= (char *)dest + dest_size)) {
+		return -EINVAL;
+	}
+
+	if (src_size > dest_size) {
+		return -EINVAL;
+	}
+
+	memcpy(dest, src, src_size);
+
+	return 0;
+}
+
+static inline int memset_s(void *dest, size_t dest_size,
+			   int data, size_t count)
+{
+	if (!dest) {
+		return -EINVAL;
+	}
+
+	if (count > dest_size) {
+		return -EINVAL;
+	}
+
+	memset(dest, data, count);
+
+	return 0;
+}
+
+#endif /* __INCLUDE_PLATFORM_STRING_H__ */


### PR DESCRIPTION
Setting up the host windows is required for the host to see
the memory content from the DSP, e.g., the tracing/logging buffers.
The firmware ready message is to signle the firmware loader that
the firmware is up and running so it can start mapping the host
windows. This allows the logs to be read.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>