### PR TITLE
dts: cpu: fix deprecated 'title' for Xtensa LX4 CPU

### DIFF
--- a/dts/bindings/cpu/cadence,tensilica-xtensa-lx4.yaml
+++ b/dts/bindings/cpu/cadence,tensilica-xtensa-lx4.yaml
@@ -1,10 +1,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-title: Cadence Tensilica Xtensa LX4 CPU
-
-description: |
-    This binding gives a base representation for Cadence Tensilica Xtensa LX4 CPU.
+description: Cadence Tensilica Xtensa LX4 CPU
 
 compatible: "cadence,tensilica-xtensa-lx4"
 


### PR DESCRIPTION
This fixes the deprecated warning for "title" and replaced it
with "description", same as the LX6 CPU file.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>