### PR TITLE
Early printk implementation, some kconfig cleanup

### DIFF
--- a/arch/xtensa/core/crt1.S
+++ b/arch/xtensa/core/crt1.S
@@ -138,7 +138,7 @@ _start:
 	movi	a0, 0
 # endif
 
-# ifdef CONFIG_SMP
+# if CONFIG_MP_NUM_CPUS > 1
 	/* Only clear BSS when running on core 0 */
 	rsr	a3, PRID
 	extui	a3, a3, 0, 8	/* extract core ID */
@@ -186,7 +186,7 @@ _start:
 
 #endif /* !XCHAL_HAVE_BOOTLOADER */
 
-#ifdef CONFIG_SMP
+#if CONFIG_MP_NUM_CPUS > 1
 	/*
 	 * z_cstart() is only for CPU #0.
 	 * Other CPUs have different entry point.
@@ -197,10 +197,9 @@ _start:
 	CALL    z_mp_entry
 
 2:
-#endif /* CONFIG_SMP */
+#endif
 
 	/* Enter C domain, never returns from here */
 	CALL	z_cstart
 
 	.size	_start, . - _start
-

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -101,7 +101,8 @@ config IPM_STM32_IPCC_PROCID
 
 config IPM_CAVS_IDC
 	bool "CAVS DSP Intra-DSP Communication (IDC) driver"
-	depends on SMP && CAVS_ICTL
+	depends on IPM && CAVS_ICTL
+	default y if CONFIG_MP_NUM_CPUS > 1 && SMP
 	help
 	  Driver for the Intra-DSP Communication (IDC) channel for
 	  cross SoC communications.

--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -12,6 +12,22 @@ config SOC_FAMILY
 	string
 	default "intel_adsp"
 
+config ADSP_LOG_WIN_BASE
+	hex "Address of host logging window"
+	default 0x9e008000
+	help
+	  Address in the aDSP memory space of the HPSRAM memory which
+	  holds the logging ring buffer.  Note that the printk layer
+	  expects this memory to be coherent in MP environments!  When
+	  used with more than one CPU, it should point into the
+	  uncached mapping of HP-SRAM.
+
+config ADSP_LOG_WIN_SIZE
+	int "Size of host logging window"
+	default 8192
+	help
+	  Size in bytes of the host logging memory
+
 # Select SoC Part No. and configuration options
 source "soc/xtensa/intel_adsp/*/Kconfig.soc"
 

--- a/soc/xtensa/intel_adsp/cavs_v15/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/cavs_v15/CMakeLists.txt
@@ -5,8 +5,7 @@ zephyr_library_link_libraries(intel_adsp_common)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(adsp.c)
 zephyr_library_sources(soc.c)
-
-zephyr_library_sources_ifdef(CONFIG_SMP soc_mp.c)
+zephyr_library_sources(soc_mp.c)
 
 set_source_files_properties(power_down.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
 zephyr_library_sources(power_down.S)

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -11,6 +11,9 @@ config SOC
 	string
 	default "intel_apl_adsp" if SOC_INTEL_CAVS_APL
 
+config MP_NUM_CPUS
+	default 2
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
 	default 19200000 if CAVS_TIMER
@@ -40,6 +43,16 @@ config TEST_LOGGING_DEFAULTS
 	default n
 	depends on TEST
 
+# The scheduler interprocessor interrupt on this platform is
+# implemented on top of the IPM driver, so build that if we have more
+# than one CPU configured
+
+config IPM_CAVS_IDC
+	default y if MP_NUM_CPUS > 1
+
+config SCHED_IPI_SUPPORTED
+	default y if SMP && IPM_CAVS_IDC
+
 if LOG
 
 config LOG_PRINTK
@@ -58,23 +71,11 @@ endif # LOG
 
 if SMP
 
-config MP_NUM_CPUS
-	default 2
-
 config XTENSA_TIMER
 	default n
 
 config CAVS_TIMER
 	default y
-
-config IPM
-	default y
-
-config IPM_CAVS_IDC
-	default y if IPM
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
 
 endif # SMP
 

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -35,9 +35,6 @@ config 2ND_LEVEL_INTERRUPTS
 config DYNAMIC_INTERRUPTS
 	default y
 
-config LOG
-	default y
-
 # To prevent test uses TEST_LOGGING_MINIMAL
 config TEST_LOGGING_DEFAULTS
 	default n

--- a/soc/xtensa/intel_adsp/cavs_v15/soc_mp.c
+++ b/soc/xtensa/intel_adsp/cavs_v15/soc_mp.c
@@ -23,9 +23,12 @@ LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 #include <sof-config.h>
 #include <platform/lib/shim.h>
 
-#ifdef CONFIG_SCHED_IPI_SUPPORTED
 #include <drivers/ipm.h>
 #include <ipm/ipm_cavs_idc.h>
+
+#if CONFIG_MP_NUM_CPUS > 1 && !defined(CONFIG_IPM_CAVS_IDC)
+#error Need to enable the IPM driver for multiprocessing
+#endif
 
 /* ROM wake version parsed by ROM during core wake up. */
 #define IDC_ROM_WAKE_VERSION	0x2
@@ -49,6 +52,7 @@ LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 
 #define IDC_MSG_POWER_UP_EXT(x)	IDC_EXTENSION((x) >> 2)
 
+#ifdef CONFIG_IPM_CAVS_IDC
 static struct device *idc;
 #endif
 
@@ -177,7 +181,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	SOC_DCACHE_FLUSH(&start_rec, sizeof(start_rec));
 
-#ifdef CONFIG_SCHED_IPI_SUPPORTED
+#ifdef CONFIG_IPM_CAVS_IDC
 	idc = device_get_binding(DT_LABEL(DT_INST(0, intel_cavs_idc)));
 #endif
 

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -27,6 +27,7 @@ zephyr_library_sources(dma.c)
 
 zephyr_library_sources(main_entry.S)
 zephyr_library_sources(mem_window.c)
+zephyr_library_sources(printk_out.c)
 
 set_source_files_properties(pm_memory.c PROPERTIES COMPILE_FLAGS -std=gnu99)
 zephyr_library_sources(pm_memory.c)

--- a/soc/xtensa/intel_adsp/common/printk_out.c
+++ b/soc/xtensa/intel_adsp/common/printk_out.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <adsp/cache.h>
+
+/* Simple char-at-a-time output rig to the host kernel from a ADSP
+ * device.  The protocol uses an array of "slots" in shared memory,
+ * each of which has a 16 bit magic number to validate and a
+ * sequential ID number.  The remaining bytes are a (potentially
+ * nul-terminated) string containing output data.
+ *
+ * IMPORTANT NOTE on cache coherence: the shared memory window is in
+ * HP-SRAM.  This has a L2 cache that is shared across the DSP cores
+ * but not (!) visible to the host CPU.  Also each DSP core has an L1
+ * cache that is incoherent (!) from the perspective of the other
+ * cores.  To handle this, we take care to access all memory through
+ * the uncached window into HP-SRAM at 0x9xxxxxxx and not the
+ * L1-cached mapping of the same memory at 0xBxxxxxxx.  Operations
+ * that should be visible to the host CPU are flushed synchronously.
+ */
+
+#define SLOT_SIZE 64
+#define SLOT_MAGIC 0x55aa
+
+#define NSLOTS (CONFIG_ADSP_LOG_WIN_SIZE / SLOT_SIZE)
+#define MSGSZ (SLOT_SIZE - sizeof(struct slot_hdr))
+
+struct slot_hdr {
+	u16_t magic;
+	u16_t id;
+};
+
+struct slot {
+	struct slot_hdr hdr;
+	char msg[MSGSZ];
+};
+
+struct metadata {
+	struct k_spinlock lock;
+	int initialized;
+	int curr_slot;   /* To which slot are we writing? */
+	int n_bytes;     /* How many bytes buffered in curr_slot */
+};
+
+/* Give it a cache line all its own! */
+static __aligned(64) union {
+	struct metadata meta;
+	u32_t cache_pad[16];
+} data_rec;
+
+#define data ((struct metadata *)(((char *) &data_rec.meta) - 0x20000000))
+
+static inline struct slot *slot(int i)
+{
+	struct slot *slots = (struct slot *)(long) CONFIG_ADSP_LOG_WIN_BASE;
+
+	return &slots[i];
+}
+
+int arch_printk_char_out(int c)
+{
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+	if (!data->initialized) {
+		slot(0)->hdr.magic = 0;
+		slot(0)->hdr.id = 0;
+		SOC_DCACHE_FLUSH(&slot(0)->hdr, sizeof(struct slot_hdr));
+		data->initialized = 1;
+	}
+
+	struct slot *s = slot(data->curr_slot);
+
+	s->msg[data->n_bytes++] = c;
+
+	if (data->n_bytes < MSGSZ) {
+		s->msg[data->n_bytes] = 0;
+	}
+
+	if (c == '\n' || data->n_bytes >= MSGSZ) {
+		data->curr_slot = (data->curr_slot + 1) % NSLOTS;
+		data->n_bytes = 0;
+		slot(data->curr_slot)->hdr.magic = 0;
+		slot(data->curr_slot)->hdr.id = s->hdr.id + 1;
+		s->hdr.magic = SLOT_MAGIC;
+		SOC_DCACHE_FLUSH(s, SLOT_SIZE);
+		SOC_DCACHE_FLUSH(slot(data->curr_slot), SLOT_SIZE);
+	}
+
+	k_spin_unlock(&data->lock, key);
+	return 0;
+}


### PR DESCRIPTION
First cut at some SOF submissions. 

One is a printk hook to use in lieu of the log backend.  Honestly, I hate the Zephyr logging system, it's async by default, will drop rapid logging by default, it's a huge chunk of code, and it's not avaialble in early boot.  Basically it's everything I don't want when debugging platform code.

Also it was easier to add MP/cache-safety to this rig than it was to the more complicated log backend.  See comments.

The other commit is pure cleanup, just there so I can test MP features without SMP turned on.