### PR TITLE
Cache management prototype (DO NOT MERGE)

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -387,6 +387,13 @@ config ARCH_HAS_RAMFUNC_SUPPORT
 config ARCH_HAS_NESTED_EXCEPTION_DETECTION
 	bool
 
+config ARCH_HAS_COHERENCE
+	bool
+	help
+	  When selected, the architecture supports the
+	  arch_mem_coherent() API and can link into incoherent/cached
+	  memory using the ".cached" linker section.
+
 #
 # Other architecture related options
 #

--- a/arch/xtensa/core/crt1.S
+++ b/arch/xtensa/core/crt1.S
@@ -138,7 +138,7 @@ _start:
 	movi	a0, 0
 # endif
 
-# ifdef CONFIG_SMP
+# if CONFIG_MP_NUM_CPUS > 1
 	/* Only clear BSS when running on core 0 */
 	rsr	a3, PRID
 	extui	a3, a3, 0, 8	/* extract core ID */
@@ -186,7 +186,7 @@ _start:
 
 #endif /* !XCHAL_HAVE_BOOTLOADER */
 
-#ifdef CONFIG_SMP
+#if CONFIG_MP_NUM_CPUS > 1
 	/*
 	 * z_cstart() is only for CPU #0.
 	 * Other CPUs have different entry point.
@@ -197,10 +197,9 @@ _start:
 	CALL    z_mp_entry
 
 2:
-#endif /* CONFIG_SMP */
+#endif
 
 	/* Enter C domain, never returns from here */
 	CALL	z_cstart
 
 	.size	_start, . - _start
-

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -60,6 +60,18 @@ static inline void arch_switch(void *switch_to, void **switched_from)
 	return xtensa_switch(switch_to, switched_from);
 }
 
+/* FIXME: we don't have a framework for including this from the SoC
+ * layer, so we define it in the arch code here.
+ */
+#ifdef CONFIG_SOC_FAMILY_INTEL_ADSP
+static inline bool arch_mem_coherent(void *ptr)
+{
+    size_t addr = (size_t) ptr;
+
+    return addr >= 0x80000000 && addr < 0xa0000000;
+}
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/ipm/Kconfig
+++ b/drivers/ipm/Kconfig
@@ -101,7 +101,8 @@ config IPM_STM32_IPCC_PROCID
 
 config IPM_CAVS_IDC
 	bool "CAVS DSP Intra-DSP Communication (IDC) driver"
-	depends on SMP && CAVS_ICTL
+	depends on IPM && CAVS_ICTL
+	default y if CONFIG_MP_NUM_CPUS > 1 && SMP
 	help
 	  Driver for the Intra-DSP Communication (IDC) channel for
 	  cross SoC communications.

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -5307,7 +5307,8 @@ static inline char *Z_THREAD_STACK_BUFFER(k_thread_stack_t *sym)
  * @param size Size of the stack memory region
  */
 #define K_THREAD_STACK_DEFINE(sym, size) \
-	struct z_thread_stack_element __noinit __aligned(STACK_ALIGN) sym[size]
+	struct z_thread_stack_element    \
+          __stackmem __aligned(STACK_ALIGN) sym[size]
 
 /**
  * @brief Calculate size of stacks to be allocated in a stack array

--- a/include/linker/section_tags.h
+++ b/include/linker/section_tags.h
@@ -38,6 +38,14 @@
 #define __nocache
 #endif /* CONFIG_NOCACHE_MEMORY */
 
+#if defined(CONFIG_KERNEL_COHERENCE)
+#define __incoherent __in_section_unique(cached)
+#define __stackmem __incoherent
+#else
+#define __incoherent /**/
+#define __stackmem __noinit
+#endif /* CONFIG_KERNEL_COHERENCE */
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_LINKER_SECTION_TAGS_H_ */

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -42,6 +42,9 @@ static ALWAYS_INLINE k_spinlock_key_t k_spin_lock(struct k_spinlock *l)
 
 #ifdef CONFIG_SPIN_VALIDATE
 	__ASSERT(z_spin_lock_valid(l), "Recursive spinlock %p", l);
+# ifdef KERNEL_COHERENCE
+	__ASSERT_NO_MSG(arch_mem_coherent(l));
+# endif
 #endif
 
 #ifdef CONFIG_SMP

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -645,6 +645,24 @@ FUNC_NORETURN void arch_syscall_oops(void *ssf);
 size_t arch_user_string_nlen(const char *s, size_t maxsize, int *err);
 #endif /* CONFIG_USERSPACE */
 
+#ifdef KERNEL_COHERENCE
+/**
+ * @brief Detect memory coherence type
+ *
+ * Required when ARCH_HAS_COHERENCE is true.  This function returns
+ * true if the byte pointed to lies within an architecture-defined
+ * "coherence region" (typically implemented with uncached memory) and
+ * can safely be used in multiprocessor code without explicit flush or
+ * invalidate operations.
+ *
+ * @note The result is for only the single byte at the specified
+ * address, this API is not required to check region boundaries or to
+ * expect misaligned pointers.  The expectation is that the code above
+ * will have queried the appropriate address(es).
+ */
+bool arch_mem_coherent(void *ptr);
+#endif
+
 /** @} */
 
 /**

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -755,6 +755,22 @@ config SCHED_IPI_SUPPORTED
 	  take an interrupt, which can be arbitrarily far in the
 	  future).
 
+config KERNEL_COHERENCE
+	bool "Place all shared data into coherent memory"
+	default y if ARCH_HAS_COHERENCE && SMP && MP_NUM_CPUS > 1
+	help
+	  When available and selected, the kernel will build in a mode
+	  where all shared data is placed in multiprocessor-coherent
+	  (generally "uncached") memory.  Thread stacks will remain
+	  cached, as will application memory declared with
+	  __incoherent.  This is intended for Zephyr SMP kernels
+	  running on cache-incoherent architectures only.  Note that
+	  when this is selected, there is an implicit API change that
+	  assumes cache coherence to any memory passed to the kernel.
+	  Code that creates kernel data structures in uncached regions
+	  may fail strangely.  Some assertions exist to catch these
+	  mistakes, but not all circumstances can be tested.
+
 endmenu
 
 config TICKLESS_IDLE

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -247,6 +247,10 @@ static void bg_thread_main(void *unused1, void *unused2, void *unused3)
 
 	z_init_static_threads();
 
+#ifdef KERNEL_COHERENCE
+	__ASSERT_NO_MSG(arch_mem_coherent(_kernel));
+#endif
+
 #ifdef CONFIG_SMP
 	z_smp_init();
 	z_sys_device_do_config_level(_SYS_INIT_LEVEL_SMP);

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -378,6 +378,10 @@ static void update_cache(int preempt_ok)
 
 static void ready_thread(struct k_thread *thread)
 {
+#ifdef KERNEL_COHERENCE
+	__ASSERT_NO_MSG(arch_mem_coherent(thread));
+#endif
+
 	if (z_is_thread_ready(thread)) {
 		sys_trace_thread_ready(thread);
 		_priq_run_add(&_kernel.ready_q.runq, thread);
@@ -595,6 +599,10 @@ static void add_thread_timeout(struct k_thread *thread, k_timeout_t timeout)
 static void pend(struct k_thread *thread, _wait_q_t *wait_q,
 		 k_timeout_t timeout)
 {
+#ifdef KERNEL_COHERENCE
+	__ASSERT_NO_MSG(arch_mem_coherent(wait_q));
+#endif
+
 	LOCKED(&sched_spinlock) {
 		add_to_waitq_locked(thread, wait_q);
 	}

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -538,6 +538,13 @@ void z_setup_new_thread(struct k_thread *new_thread,
 #endif
 #endif
 
+#ifdef KERNEL_COHERENCE
+        /* Check that the thread object is safe, but that the stack is
+         * still cached! */
+	__ASSERT_NO_MSG(arch_mem_coherent(new_thread));
+	__ASSERT_NO_MSG(!arch_mem_coherent(stack));
+#endif
+
 	arch_new_thread(new_thread, stack, stack_size, entry, p1, p2, p3,
 			  prio, options);
 

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -86,6 +86,9 @@ static s32_t next_timeout(void)
 void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 		   k_timeout_t timeout)
 {
+#ifdef KERNEL_COHERENCE
+	__ASSERT_NO_MSG(arch_mem_coherent(to));
+#endif
 #ifdef CONFIG_LEGACY_TIMEOUT_API
 	k_ticks_t ticks = timeout;
 #else

--- a/samples/hello_world/prj.conf
+++ b/samples/hello_world/prj.conf
@@ -1,1 +1,2 @@
 # nothing here
+CONFIG_KERNEL_COHERENCE=y

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -7,7 +7,98 @@
 #include <zephyr.h>
 #include <sys/printk.h>
 
+#define STACK_SIZE 2048
+K_THREAD_STACK_DEFINE(stack, STACK_SIZE);
+
+/* Weirdness with a non-array "first_dword" because -Warray-bounds is
+ * too smart and flips out when we calculate the uncached mapping, no
+ * matter how hard I try to hide the array.
+ */
+static __aligned(64) struct {
+	u32_t first_dword;
+	u32_t rest[15];
+} cacheline;
+
+/* Test rig to do an operation through cached/uncached pointers.  Logs
+ * what is going to happen, executes it, makes sure the compiler
+ * doens't muck with the results, and prints the old and new values
+ */
+#define CACHEOP(expr) do {				\
+	printk("%s\n", #expr);			\
+	u32_t u0 = *ucp, c0 = *cp;			\
+	__asm__ volatile("" : : : "memory");		\
+	expr;						\
+	__asm__ volatile("" : : : "memory");		\
+	printk(" :: *cp = %d -> %d, *ucp = %d -> %d\n", c0, *cp, u0, *ucp); \
+} while(0)
+
+static volatile void *uncache_ptr(volatile void *p)
+{
+	return (void*)(((long)p) & ~0x20000000);
+}
+
+void check_cache(void)
+{
+	for (int region = 0; region < 8; region++) {
+		u32_t addr = 0x20000000 * region;
+		u32_t attrib;
+
+		__asm__ volatile("rdtlb1 %0, %1" : "=r"(attrib) : "r"(addr));
+		printk("region %d @0x%x cachattr 0x%x\n", region, addr, attrib & 0xf);
+	}
+
+	/* Cached and uncached pointers to the same value. */
+        long addr = (long)&cacheline.first_dword;
+	volatile u32_t *cp = (void *)(addr | 0x20000000);
+	volatile u32_t *ucp = (void *)(addr & ~0x20000000);
+
+	printk("cp %p ucp %p\n", cp, ucp);
+
+	*cp = *ucp = 0;
+
+	/* Set the cached pointer to 1, only it should show the results */
+	CACHEOP(*cp = 1);
+
+	/* Set the uncached pointer, the cached one shouldn't change */
+	CACHEOP(*ucp = 2);
+
+	/* Flush the cache from before, BOTH should become 1 */
+	CACHEOP(SOC_DCACHE_FLUSH((void*)cp, sizeof(*cp)));
+
+	/* Now prime the cache with a new value, and invalidate it */
+	CACHEOP(*cp = 3);
+	CACHEOP(SOC_DCACHE_INVALIDATE((void*)cp, sizeof(*cp)));
+}
+
+FUNC_NORETURN void cputop(void *data)
+{
+	printk("Second CPU!\n");
+	check_cache();
+
+	while(1) {
+		for(volatile int i=0; i<10000000; i++);
+		printk(".\n");
+	}
+}
+
+int __incoherent cached_int;
+int __attribute__((__section__(".cached"))) cached2_int;
+
+static int bss_int;
+
 void main(void)
 {
 	printk("Hello World! %s\n", CONFIG_BOARD);
+
+        int stack_int;
+	printk("&cached_int = %p\n", &cached_int);
+	printk("&cached2_int = %p\n", &cached2_int);
+        printk("&bss_int = %p\n", &bss_int);
+        printk("&stack_int = %p\n", &stack_int);
+
+	check_cache();
+
+	arch_start_cpu(1, stack, STACK_SIZE, cputop, NULL);
+
+	while(1);
 }

--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -5,6 +5,7 @@
 
 config SOC_FAMILY_INTEL_ADSP
 	bool
+	select ARCH_HAS_COHERENCE
 
 if SOC_FAMILY_INTEL_ADSP
 

--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -12,6 +12,22 @@ config SOC_FAMILY
 	string
 	default "intel_adsp"
 
+config ADSP_LOG_WIN_BASE
+	hex "Address of host logging window"
+	default 0x9e008000
+	help
+	  Address in the aDSP memory space of the HPSRAM memory which
+	  holds the logging ring buffer.  Note that the printk layer
+	  expects this memory to be coherent in MP environments!  When
+	  used with more than one CPU, it should point into the
+	  uncached mapping of HP-SRAM.
+
+config ADSP_LOG_WIN_SIZE
+	int "Size of host logging window"
+	default 8192
+	help
+	  Size in bytes of the host logging memory
+
 # Select SoC Part No. and configuration options
 source "soc/xtensa/intel_adsp/*/Kconfig.soc"
 

--- a/soc/xtensa/intel_adsp/cavs_v15/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/cavs_v15/CMakeLists.txt
@@ -4,8 +4,7 @@ zephyr_library()
 zephyr_library_link_libraries(intel_adsp_common)
 zephyr_library_include_directories(${ZEPHYR_BASE}/drivers)
 zephyr_library_sources(adsp.c)
-
-zephyr_library_sources_ifdef(CONFIG_SMP soc_mp.c)
+zephyr_library_sources(soc_mp.c)
 
 set_source_files_properties(power_down.S PROPERTIES COMPILE_FLAGS -DASSEMBLY)
 zephyr_library_sources(power_down.S)

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -11,6 +11,9 @@ config SOC
 	string
 	default "intel_apl_adsp" if SOC_INTEL_CAVS_APL
 
+config MP_NUM_CPUS
+	default 2
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
 	default 19200000 if CAVS_TIMER
@@ -40,6 +43,16 @@ config TEST_LOGGING_DEFAULTS
 	default n
 	depends on TEST
 
+# The scheduler interprocessor interrupt on this platform is
+# implemented on top of the IPM driver, so build that if we have more
+# than one CPU configured
+
+config IPM_CAVS_IDC
+	default y if MP_NUM_CPUS > 1
+
+config SCHED_IPI_SUPPORTED
+	default y if SMP && IPM_CAVS_IDC
+
 if LOG
 
 config LOG_PRINTK
@@ -58,23 +71,11 @@ endif # LOG
 
 if SMP
 
-config MP_NUM_CPUS
-	default 2
-
 config XTENSA_TIMER
 	default n
 
 config CAVS_TIMER
 	default y
-
-config IPM
-	default y
-
-config IPM_CAVS_IDC
-	default y if IPM
-
-config SCHED_IPI_SUPPORTED
-	default y if IPM_CAVS_IDC
 
 endif # SMP
 

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -35,9 +35,6 @@ config 2ND_LEVEL_INTERRUPTS
 config DYNAMIC_INTERRUPTS
 	default y
 
-config LOG
-	default y
-
 # To prevent test uses TEST_LOGGING_MINIMAL
 config TEST_LOGGING_DEFAULTS
 	default n

--- a/soc/xtensa/intel_adsp/cavs_v15/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v15/linker.ld
@@ -425,7 +425,7 @@ SECTIONS
     *(.noinit.*)
   } >ram :ram_phdr
 
-  .lit4 SEGSTART_CACHED : ALIGN(4)
+  .lit4 : ALIGN(4)
   {
     _lit4_start = ABSOLUTE(.);
     *(*.lit4)
@@ -465,11 +465,13 @@ SECTIONS
 #define ROMABLE_REGION ucram :ucram_phdr
 #include <linker/common-ram.ld>
 
-  /* ANDY TEST */
-  .ucram SEGSTART_UNCACHED :
+  /* This section is cached.  By default it contains only declared
+   * thread stacks, but applications can put symbols here too.
+   */
+  .cached SEGSTART_CACHED :
   {
-    *(.ucram)
-  } >ucram :ucram_phdr
+    *(.cached .cached.*)
+  } >ram :ram_phdr
 
   .bss SEGSTART_UNCACHED (NOLOAD) : ALIGN(4096)
   {

--- a/soc/xtensa/intel_adsp/cavs_v15/linker.ld
+++ b/soc/xtensa/intel_adsp/cavs_v15/linker.ld
@@ -24,9 +24,26 @@ OUTPUT_ARCH(xtensa)
 PROVIDE(__memctl_default = 0x00000000);
 PROVIDE(_MemErrorHandler = 0x00000000);
 
-#define RAMABLE_REGION ram :ram_phdr
-#define ROMABLE_REGION ram :ram_phdr
 #define LPRAM_REGION lpram
+
+/* DSP RAM regions (all of them) are mapped twice on the DSP: once in
+ * a 512MB region from 0x80000000-0x9fffffff and again from
+ * 0xa0000000-0xbfffffff.  The first mapping is set up to bypass the
+ * L1 cache, so it must be used when multiprocessor coherence is
+ * desired, where the latter mapping is best used for processor-local
+ * data (e.g. stacks) or shared data that is managed with explicit
+ * cache flush/invalidate operations.
+ *
+ * These macros will set up a segment start address correctly,
+ * including alignment to a cache line.  Be sure to also emit the
+ * section to ">ram :ram_phdr" or ">ucram :ucram_phdr" as
+ * appropriate. (Forgetting the correct PHDR will actually work, as
+ * the output tooling ignores it, but it will cause the linker to emit
+ * 512MB of unused data into the output file!)
+ *
+ */
+#define SEGSTART_CACHED   (ALIGN(64) | 0x20000000)
+#define SEGSTART_UNCACHED (ALIGN(64) & ~0x20000000)
 
 MEMORY
 {
@@ -96,6 +113,9 @@ MEMORY
   ram :
 	org = RAM_BASE,
 	len = RAM_SIZE
+  ucram :
+	org = RAM_BASE - 0x20000000,
+	len = RAM_SIZE
 #ifdef CONFIG_GEN_ISR_TABLES
   IDT_LIST :
 	org = IDT_BASE,
@@ -137,7 +157,7 @@ PHDRS
   vector_double_lit_phdr PT_LOAD;
   vector_double_text_phdr PT_LOAD;
   ram_phdr PT_LOAD;
-
+  ucram_phdr PT_LOAD;
   static_uuid_entries_phdr PT_NOTE;
   static_log_entries_phdr PT_NOTE;
 }
@@ -389,6 +409,8 @@ SECTIONS
     _module_init_end = ABSOLUTE(.);
   } >ram :ram_phdr
 
+#define RAMABLE_REGION ram :ram_phdr
+#define ROMABLE_REGION ram :ram_phdr
 #include <linker/common-rom.ld>
 
   .fw_ready : ALIGN(4)
@@ -403,7 +425,16 @@ SECTIONS
     *(.noinit.*)
   } >ram :ram_phdr
 
-  .data : ALIGN(4)
+  .lit4 SEGSTART_CACHED : ALIGN(4)
+  {
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+  } >ram :ram_phdr
+
+  .data SEGSTART_UNCACHED : ALIGN(4)
   {
     _data_start = ABSOLUTE(.);
     *(.data)
@@ -422,18 +453,25 @@ SECTIONS
     *(.gna_model)
     _data_end = ABSOLUTE(.);
     . = ALIGN(4096);
-  } >ram :ram_phdr
-  .lit4 : ALIGN(4)
-  {
-    _lit4_start = ABSOLUTE(.);
-    *(*.lit4)
-    *(.lit4.*)
-    *(.gnu.linkonce.lit4.*)
-    _lit4_end = ABSOLUTE(.);
-  } >ram :ram_phdr
+  } >ucram :ucram_phdr
+
+/* These values need to change in our scheme, where the common-ram
+ * sections need to be linked in safe/uncached memory but common-rom
+ * wants to use the cache
+  */
+#undef RAMABLE_REGION
+#undef ROMABLE_REGION
+#define RAMABLE_REGION ucram :ucram_phdr
+#define ROMABLE_REGION ucram :ucram_phdr
 #include <linker/common-ram.ld>
 
-  .bss (NOLOAD) : ALIGN(4096)
+  /* ANDY TEST */
+  .ucram SEGSTART_UNCACHED :
+  {
+    *(.ucram)
+  } >ucram :ucram_phdr
+
+  .bss SEGSTART_UNCACHED (NOLOAD) : ALIGN(4096)
   {
     . = ALIGN(4096);
     _bss_start = ABSOLUTE(.);
@@ -452,7 +490,10 @@ SECTIONS
     *(COMMON)
     . = ALIGN(8);
     _bss_end = ABSOLUTE(.);
-  } >ram :ram_phdr
+  } >ucram :ucram_phdr
+
+  /* Re-adjust to the upper mapping for the final symbols below */
+  . = SEGSTART_CACHED;
 
   /* stack */
   _end = ALIGN(8);

--- a/soc/xtensa/intel_adsp/cavs_v15/soc_mp.c
+++ b/soc/xtensa/intel_adsp/cavs_v15/soc_mp.c
@@ -23,9 +23,12 @@ LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 #include <sof-config.h>
 #include <platform/lib/shim.h>
 
-#ifdef CONFIG_SCHED_IPI_SUPPORTED
 #include <drivers/ipm.h>
 #include <ipm/ipm_cavs_idc.h>
+
+#if CONFIG_MP_NUM_CPUS > 1 && !defined(CONFIG_IPM_CAVS_IDC)
+#error Need to enable the IPM driver for multiprocessing
+#endif
 
 /* ROM wake version parsed by ROM during core wake up. */
 #define IDC_ROM_WAKE_VERSION	0x2
@@ -49,6 +52,7 @@ LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 
 #define IDC_MSG_POWER_UP_EXT(x)	IDC_EXTENSION((x) >> 2)
 
+#ifdef CONFIG_IPM_CAVS_IDC
 static struct device *idc;
 #endif
 
@@ -177,7 +181,7 @@ void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 
 	SOC_DCACHE_FLUSH(&start_rec, sizeof(start_rec));
 
-#ifdef CONFIG_SCHED_IPI_SUPPORTED
+#ifdef CONFIG_IPM_CAVS_IDC
 	idc = device_get_binding(DT_LABEL(DT_INST(0, intel_cavs_idc)));
 #endif
 

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -28,6 +28,7 @@ zephyr_library_sources(dma.c)
 zephyr_library_sources(main_entry.S)
 zephyr_library_sources(mem_window.c)
 zephyr_library_sources(soc.c)
+zephyr_library_sources(printk_out.c)
 
 set_source_files_properties(pm_memory.c PROPERTIES COMPILE_FLAGS -std=gnu99)
 zephyr_library_sources(pm_memory.c)

--- a/soc/xtensa/intel_adsp/common/bootloader.cmake
+++ b/soc/xtensa/intel_adsp/common/bootloader.cmake
@@ -12,12 +12,17 @@ if(EXISTS ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/bootloader/CMakeLists.txt)
   add_subdirectory(${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/bootloader ${build_dir})
 endif()
 
+set(ELF_FIX ${SOC_DIR}/${ARCH}/${SOC_FAMILY}/common/fix_elf_addrs.py)
+
 add_custom_target(
   process_elf ALL
   DEPENDS base_module
   DEPENDS ${ZEPHYR_FINAL_EXECUTABLE}
   COMMAND ${CMAKE_OBJCOPY} --dump-section .data=mod-apl.bin ${CMAKE_BINARY_DIR}/zephyr/soc/xtensa/${SOC_FAMILY}/common/bootloader/libbase_module.a
   COMMAND ${CMAKE_OBJCOPY} --add-section .module=mod-apl.bin --set-section-flags .module=load,readonly ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf.mod
+
+  # Adjust final section addresses so they all appear in the cached region.
+  COMMAND ${ELF_FIX} ${CMAKE_OBJCOPY} ${CMAKE_BINARY_DIR}/zephyr/zephyr.elf.mod
   )
 
 add_custom_target(

--- a/soc/xtensa/intel_adsp/common/fix_elf_addrs.py
+++ b/soc/xtensa/intel_adsp/common/fix_elf_addrs.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# ADSP devices have their RAM regions mapped twice, once in the 512MB
+# region from 0x80000000-0x9fffffff and again from
+# 0xa0000000-0xbfffffff.  The first mapping is set in the CPU to
+# bypass the L1 cache, and so access through pointers in that region
+# is coherent between CPUs (but slow).  The second region accesses the
+# same memory through the L1 cache and requires careful flushing when
+# used with shared data.
+#
+# This distinction is exposed in the linker script, where some symbols
+# (e.g. stack regions) are linked into cached memory, but others
+# (general kernel memory) are not.  But the rimage signing tool
+# doesn't understand that and fails if regions aren't contiguous.
+#
+# Walk the sections in the ELF file, changing the VMA/LMA of each
+# uncached section to the equivalent region in the 
+
+import os
+import sys
+from elftools.elf.elffile import ELFFile
+
+objcopy_bin = sys.argv[1]
+elffile = sys.argv[2]
+
+fixup =[]
+with open(elffile, "rb") as fd:
+    elf = ELFFile(fd)
+    for s in elf.iter_sections():
+        addr = s.header.sh_addr
+        if addr >= 0x80000000 and addr < 0xa0000000:
+            print(f"fix_elf_addrs.py: Moving section {s.name} to cached SRAM region")
+            fixup.append(s.name)
+
+for s in fixup:
+    cmd = f"{objcopy_bin} --change-section-address {s}+0x20000000 {elffile}"
+    print(cmd)
+    os.system(cmd)

--- a/soc/xtensa/intel_adsp/common/printk_out.c
+++ b/soc/xtensa/intel_adsp/common/printk_out.c
@@ -49,7 +49,8 @@ static __aligned(64) union {
 	u32_t cache_pad[16];
 } data_rec;
 
-#define data ((struct metadata *)(((char *) &data_rec.meta) - 0x20000000))
+/* Force to the low/uncached mapping, regardless of how it was linked */
+#define data ((struct metadata *)(((long) &data_rec.meta) & ~0x20000000))
 
 static inline struct slot *slot(int i)
 {

--- a/soc/xtensa/intel_adsp/common/printk_out.c
+++ b/soc/xtensa/intel_adsp/common/printk_out.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+#include <adsp/cache.h>
+
+/* Simple char-at-a-time output rig to the host kernel from a ADSP
+ * device.  The protocol uses an array of "slots" in shared memory,
+ * each of which has a 16 bit magic number to validate and a
+ * sequential ID number.  The remaining bytes are a (potentially
+ * nul-terminated) string containing output data.
+ *
+ * IMPORTANT NOTE on cache coherence: the shared memory window is in
+ * HP-SRAM.  Each DSP core has an L1 cache that is incoherent (!) from
+ * the perspective of the other cores.  To handle this, we take care
+ * to access all memory through the uncached window into HP-SRAM at
+ * 0x9xxxxxxx and not the L1-cached mapping of the same memory at
+ * 0xBxxxxxxx.
+ */
+
+#define SLOT_SIZE 64
+#define SLOT_MAGIC 0x55aa
+
+#define NSLOTS (CONFIG_ADSP_LOG_WIN_SIZE / SLOT_SIZE)
+#define MSGSZ (SLOT_SIZE - sizeof(struct slot_hdr))
+
+struct slot_hdr {
+	u16_t magic;
+	u16_t id;
+};
+
+struct slot {
+	struct slot_hdr hdr;
+	char msg[MSGSZ];
+};
+
+struct metadata {
+	struct k_spinlock lock;
+	int initialized;
+	int curr_slot;   /* To which slot are we writing? */
+	int n_bytes;     /* How many bytes buffered in curr_slot */
+};
+
+/* Give it a cache line all its own! */
+static __aligned(64) union {
+	struct metadata meta;
+	u32_t cache_pad[16];
+} data_rec;
+
+#define data ((struct metadata *)(((char *) &data_rec.meta) - 0x20000000))
+
+static inline struct slot *slot(int i)
+{
+	struct slot *slots = (struct slot *)(long) CONFIG_ADSP_LOG_WIN_BASE;
+
+	return &slots[i];
+}
+
+int arch_printk_char_out(int c)
+{
+	k_spinlock_key_t key = k_spin_lock(&data->lock);
+
+	if (!data->initialized) {
+		slot(0)->hdr.magic = 0;
+		slot(0)->hdr.id = 0;
+		data->initialized = 1;
+	}
+
+	struct slot *s = slot(data->curr_slot);
+
+	s->msg[data->n_bytes++] = c;
+
+	if (data->n_bytes < MSGSZ) {
+		s->msg[data->n_bytes] = 0;
+	}
+
+	if (c == '\n' || data->n_bytes >= MSGSZ) {
+		data->curr_slot = (data->curr_slot + 1) % NSLOTS;
+		data->n_bytes = 0;
+		slot(data->curr_slot)->hdr.magic = 0;
+		slot(data->curr_slot)->hdr.id = s->hdr.id + 1;
+		s->hdr.magic = SLOT_MAGIC;
+	}
+
+	k_spin_unlock(&data->lock, key);
+	return 0;
+}


### PR DESCRIPTION
First cut of the promised cached management layer for SMP synchronization.  Executive summary is that there is a new KERNEL_COHERENCE kconfig:

1. It's set by default when the arch/soc layer support it and when SMP is selected with 2+ CPUs

2. All writable data is uncached by default, and thus usable safely in MP contexts

3. All read-only data (and code, obviously) is still cached

4. Stacks declared with the standard macros are by definition CPU-local and so are cached

5. Applications can use a "__incoherent" attribute on their own static data to put it in cached memory.

6. This only works on Up Squared right now.  There's a distressing amount of grunt work (and probably a decent amount of rewriting) involved in getting all the variant linker scripts working.

7. Try the hello_world rig in the last patch to see a hacky demo of how the cacheable regions in memory work at the hardware level.

8. This needs a rebase.  I'm about a week behind current SoF code.

9. Unfortunately you can't try it directly with SMP right now, because SMP seems not to be building in the current tree (or rather the tree I'm on top of).  I'll investigate.