### PR TITLE
samples/audio/sof: import sof/src/arch/xtensa/  apollolake_defconfig

### DIFF
--- a/samples/audio/sof/boards/up_squared_adsp.conf
+++ b/samples/audio/sof/boards/up_squared_adsp.conf
@@ -1,0 +1,15 @@
+# Partial copy of:
+#   modules/sof/src/arch/xtensa/configs/apollolake_defconfig
+
+### SOF module ###
+
+# Considering all the duplication in modules/sof/
+# /src/arch/xtensa/configs, this file will likely be the starting point
+# of a similar duplication in this directory, so here's a reminder that
+# some other XCC configs there need -Os:
+# CONFIG_OPTIMIZE_FOR_SIZE=y
+
+CONFIG_APOLLOLAKE=y
+
+CONFIG_LP_MEMORY_BANKS=2
+CONFIG_HP_MEMORY_BANKS=8

--- a/samples/audio/sof/prj.conf
+++ b/samples/audio/sof/prj.conf
@@ -1,4 +1,17 @@
 CONFIG_LOG=y
 
+
+###  SOF module ###
 CONFIG_SOF=y
+
 CONFIG_HEAP_MEM_POOL_SIZE=192000
+
+# Partial copy from:
+#   modules/sof/src/arch/xtensa/configs/apollolake_defconfig
+
+# SOF Debug
+CONFIG_PERFORMANCE_COUNTERS=y
+
+# SOF Drivers
+CONFIG_CAVS_DMIC=y
+CONFIG_CAVS_SSP=y


### PR DESCRIPTION
[ this MUST be merged at the same time than https://github.com/thesofproject/sof/pull/3021 ]

Import modules/audio/sof/src/arch/xtensa/configs/apollolake_defconfig
into prj.conf and new boards/up_squared_adsp.conf

Signed-off-by: Marc Herbert <marc.herbert@intel.com>