### PR TITLE
intel_adsp_*/doc: fix duplicate .rst labels

### DIFF
--- a/boards/xtensa/intel_adsp_cavs18/doc/index.rst
+++ b/boards/xtensa/intel_adsp_cavs18/doc/index.rst
@@ -1,4 +1,4 @@
-.. _Up_Squared_Audio_DSP:
+.. _Up_Xtreme_Audio_DSP:
 
 Up Xtreme Audio DSP
 ####################

--- a/boards/xtensa/intel_adsp_cavs20/doc/index.rst
+++ b/boards/xtensa/intel_adsp_cavs20/doc/index.rst
@@ -1,4 +1,4 @@
-.. _Up_Squared_Audio_DSP:
+.. _Intel_Audio_DSP_CAVS20:
 
 Up Xtreme Audio DSP
 ####################

--- a/boards/xtensa/intel_adsp_cavs25/doc/index.rst
+++ b/boards/xtensa/intel_adsp_cavs25/doc/index.rst
@@ -1,4 +1,4 @@
-.. _Up_Squared_Audio_DSP:
+.. _Intel_Audio_DSP_CAVS25:
 
 Up Xtreme Audio DSP
 ####################


### PR DESCRIPTION
Quick fix purely to make the build green again.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>