### PR TITLE
soc/intel_adsp: Fix window address

### DIFF
--- a/boards/xtensa/up_squared_adsp/tools/adsplog.py
+++ b/boards/xtensa/up_squared_adsp/tools/adsplog.py
@@ -8,11 +8,11 @@ import mmap
 MAP_SIZE = 8192
 SLOT_SIZE = 64
 
-# Location of the log output window within the mapping of the SRAM
-# (BAR4) on the PCI device.  These numbers are cribbed from existing
-# scripting, I don't know what they really mean or where the spec for
-# these protocols is.  The driver on the DSP just hard codes an
-# address.
+# Location of the log output window within the DSP BAR on the PCI
+# device.  The hardware provides 4x 128k "windows" starting at 512kb
+# in the BAR which the DSP software can map to 4k-aligned locations
+# within its own address space.  By convention log output is an 8k
+# region at window index 3.
 WIN_OFFSET = 0x80000
 WIN_ID = 3
 WIN_SIZE = 0x20000

--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -13,22 +13,6 @@ config SOC_FAMILY
 	string
 	default "intel_adsp"
 
-config ADSP_LOG_WIN_BASE
-	hex "Address of host logging window"
-	default 0x9e008000
-	help
-	  Address in the aDSP memory space of the HPSRAM memory which
-	  holds the logging ring buffer.  Note that the printk layer
-	  expects this memory to be coherent in MP environments!  When
-	  used with more than one CPU, it should point into the
-	  uncached mapping of HP-SRAM.
-
-config ADSP_LOG_WIN_SIZE
-	int "Size of host logging window"
-	default 8192
-	help
-	  Size in bytes of the host logging memory
-
 # Select SoC Part No. and configuration options
 source "soc/xtensa/intel_adsp/*/Kconfig.soc"
 

--- a/soc/xtensa/intel_adsp/common/printk_out.c
+++ b/soc/xtensa/intel_adsp/common/printk_out.c
@@ -24,8 +24,13 @@
 #define SLOT_SIZE 64
 #define SLOT_MAGIC 0x55aa
 
-#define NSLOTS (CONFIG_ADSP_LOG_WIN_SIZE / SLOT_SIZE)
+#define NSLOTS (SRAM_TRACE_SIZE / SLOT_SIZE)
 #define MSGSZ (SLOT_SIZE - sizeof(struct slot_hdr))
+
+/* Translates a SRAM pointer into an address of the same memory in the
+ * uncached region from 0x80000000-0x9fffffff
+ */
+#define UNCACHED_PTR(p) ((void*)(((int)p) & ~0x20000000))
 
 struct slot_hdr {
 	u16_t magic;
@@ -50,12 +55,11 @@ static __aligned(64) union {
 	u32_t cache_pad[16];
 } data_rec;
 
-/* Force the pointer into the uncached region no matter how it was linked */
-#define data ((struct metadata *)(((long) &data_rec.meta) & ~0x20000000))
+#define data ((struct metadata *)UNCACHED_PTR(&data_rec.meta))
 
 static inline struct slot *slot(int i)
 {
-	struct slot *slots = (struct slot *)(long) CONFIG_ADSP_LOG_WIN_BASE;
+	struct slot *slots = UNCACHED_PTR(SRAM_TRACE_BASE);
 
 	return &slots[i];
 }
@@ -65,15 +69,6 @@ int arch_printk_char_out(int c)
 	k_spinlock_key_t key = k_spin_lock(&data->lock);
 
 	if (!data->initialized) {
-		/* Ensure the window registers are set up to allow
-		 * host access.  In general this is done by the
-		 * bootloader, but potentially not early enough
-		 */
-		sys_write32(SRAM_TRACE_SIZE | 0x7,
-			    DMWLO(3));
-		sys_write32(SRAM_TRACE_BASE | DMWBA_READONLY | DMWBA_ENABLE,
-			    DMWBA(3));
-
 		slot(0)->hdr.magic = 0;
 		slot(0)->hdr.id = 0;
 		data->curr_slot = data->n_bytes = 0;


### PR DESCRIPTION
The address of the trace buffer changed and this code was still using
its own copy.  Use the SRAM_TRACE_{BASE,SIZE} values provided by the
soc headers and remove the kconfig one.

Also remove the window register settings, which aren't necessary (they
were holdovers from a variant that was logging in the bootloader, but
that hasn't merged).

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>