### PR TITLE
soc/intel_adsp: Make the HDA timer the default always

### DIFF
--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -17,6 +17,12 @@ config SMP
 config MP_NUM_CPUS
 	default 2
 
+config XTENSA_TIMER
+	default n
+
+config CAVS_TIMER
+	default y
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 400000000 if XTENSA_TIMER
 	default 19200000 if CAVS_TIMER
@@ -72,12 +78,6 @@ if SMP
 
 config SCHED_IPI_SUPPORTED
 	default y if IPM_CAVS_IDC
-
-config XTENSA_TIMER
-	default n
-
-config CAVS_TIMER
-	default y
 
 endif # SMP
 


### PR DESCRIPTION
[There's some justified thinking that this timer default might be the source of the audio underruns that are being heard in the current tree.  I can't confirm because I don't have audio working, but FWIW I think the choice is correct anyway.]

The CAVS_TIMER was originally written because the CCOUNT values are
skewed between SMP CPUs, so it's the default when SMP=y.  But really
it should be the default always, the 19.2 MHz timer is plenty fast
enough to be the Zephyr cycle timer, and it's rate is synchronized
across the whole system (including the host CPU), making it a better
choice for timing-sensitive applications.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>