### PR TITLE
soc/intel_adsp: Leave interrupts disabled at MP startup

### DIFF
--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -78,7 +78,7 @@ static void *mp_top;
 
 static void mp_entry2(void)
 {
-	volatile int ps, ie;
+	volatile int ie;
 	u32_t idc_reg;
 
 	/* We don't know what the boot ROM might have touched and we
@@ -88,15 +88,8 @@ static void mp_entry2(void)
 
 	/* Copy over VECBASE from the main CPU for an initial value
 	 * (will need to revisit this if we ever allow a user API to
-	 * change interrupt vectors at runtime).  Make sure interrupts
-	 * are locally disabled, then synthesize a PS value that will
-	 * enable them for the user code to pass to irq_unlock()
-	 * later.
+	 * change interrupt vectors at runtime).
 	 */
-	__asm__ volatile("rsr.PS %0" : "=r"(ps));
-	ps &= ~(PS_EXCM_MASK | PS_INTLEVEL_MASK);
-	__asm__ volatile("wsr.PS %0" : : "r"(ps));
-
 	ie = 0;
 	__asm__ volatile("wsr.INTENABLE %0" : : "r"(ie));
 	__asm__ volatile("wsr.VECBASE %0" : : "r"(start_rec.vecbase));


### PR DESCRIPTION
[Discovered this when rebasing.  This is benign in the sof branch but recent changes in Zephyr upstream have introduced an assertion on the SMP startup path that detects the enabled interrupts and (correctly) fails.   I have it also in my andyross/zephyr/sof-rebased branch at https://github.com/andyross/zephyr/tree/sof-rebased ]

This had some code that was pasted in from esp32 that was inexplicably
enabling interrupts when starting an auxiliary CPU.  The original
intent was that the resulting key would be passed down to the OS, but
that's a legacy SMP mechanism and unused.  What it actually did was
SET the resulting value in PS.INTLEVEL, enabling interrupts globally
before the CPU is ready to handle them.

Just remove.  The system doesn't need to enable interrupts until the
entrance to the first user thread on this CPU, which will do it
automatically as part of the context switch.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>