### PR TITLE
soc/intel_adsp: Remove "if SOF" predication from tick rate

### DIFF
--- a/soc/xtensa/intel_adsp/baytrail_adsp/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/baytrail_adsp/Kconfig.defconfig.series
@@ -12,7 +12,7 @@ config SOC
 	default "intel_byt_adsp"
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 50000 if SOF
+	default 50000
 
 config IRQ_OFFLOAD_INTNUM
 	default 0

--- a/soc/xtensa/intel_adsp/broadwell_adsp/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/broadwell_adsp/Kconfig.defconfig.series
@@ -12,7 +12,7 @@ config SOC
 	default "intel_bdw_adsp"
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 50000 if SOF
+	default 50000
 
 config IRQ_OFFLOAD_INTNUM
 	default 0

--- a/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v15/Kconfig.defconfig.series
@@ -28,7 +28,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 19200000 if CAVS_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 50000 if SOF
+	default 50000
 
 config IRQ_OFFLOAD_INTNUM
 	default 0

--- a/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v18/Kconfig.defconfig.series
@@ -16,7 +16,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 19200000 if CAVS_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 50000 if SOF
+	default 50000
 
 config IRQ_OFFLOAD_INTNUM
 	default 0

--- a/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v20/Kconfig.defconfig.series
@@ -16,7 +16,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 19200000 if CAVS_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 50000 if SOF
+	default 50000
 
 config IRQ_OFFLOAD_INTNUM
 	default 0

--- a/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
+++ b/soc/xtensa/intel_adsp/cavs_v25/Kconfig.defconfig.series
@@ -16,7 +16,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 19200000 if CAVS_TIMER
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 50000 if SOF
+	default 50000
 
 config IRQ_OFFLOAD_INTNUM
 	default 0


### PR DESCRIPTION
No need for predicating a default like this.  The only non-SOF Zephyr
apps that anyone cares about are test cases, and there we really want
to be testing the platform defaults used by real apps (well, in a
handful of cases tests set their own tick rate for local reasons).

The 50 kHz number seems to work fine.  Let's just make that the
universal default.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>