### PR TITLE
intel_adsp: ace: Restore IDC interrupt on D3 exit

### DIFF
--- a/soc/xtensa/intel_adsp/ace/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace/multiprocessing.c
@@ -78,6 +78,17 @@ void soc_mp_init(void)
 	soc_cpus_active[0] = true;
 }
 
+#ifdef CONFIG_ADSP_IMR_CONTEXT_SAVE
+/*
+ * Called after exiting D3 state when context restore is enabled.
+ * Re-enables IDC interrupt again for all cores. Called once from core 0.
+ */
+void soc_mp_on_d3_exit(void)
+{
+	soc_mp_init();
+}
+#endif
+
 void soc_start_core(int cpu_num)
 {
 	int retry = CORE_POWER_CHECK_NUM;

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -73,6 +73,14 @@ uint8_t *global_imr_ram_storage;
  * @biref a d3 restore boot entry point
  */
 extern void boot_entry_d3_restore(void);
+
+/*
+ * @brief re-enables IDC interrupt for all cores after exiting D3 state
+ *
+ * Called once from core 0
+ */
+extern void soc_mp_on_d3_exit(void);
+
 #else
 
 /*
@@ -319,6 +327,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 			imr_layout->imr_state.header.imr_ram_storage = NULL;
 			mem_window_idle_exit();
 			sys_clock_idle_exit();
+			soc_mp_on_d3_exit();
 		}
 #endif /* CONFIG_ADSP_IMR_CONTEXT_SAVE */
 		soc_cpus_active[cpu] = true;


### PR DESCRIPTION
After exiting D3 state if context save is enabled, IDC interrupt must be re-enabled again for all cores.