### PR TITLE
[MTL-006] kernel: idle: clock switch refactor

### DIFF
--- a/kernel/init.c
+++ b/kernel/init.c
@@ -48,9 +48,6 @@ struct z_kernel _kernel;
 __pinned_bss
 atomic_t _cpus_active;
 
-__pinned_bss
-atomic_t _cpus_idleing;
-
 /* init/main and idle threads */
 K_THREAD_PINNED_STACK_DEFINE(z_main_stack, CONFIG_MAIN_STACK_SIZE);
 struct k_thread z_main_thread;

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -231,7 +231,6 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 	/* save interrupt state and turn off all interrupts */
 	core_desc[cpu].intenable = XTENSA_RSR("INTENABLE");
 	z_xt_ints_off(0xffffffff);
-	(void)atomic_dec(&_cpus_idleing);
 
 	if (state == PM_STATE_SOFT_OFF) {
 		core_desc[cpu].bctl = DSPCS.bootctl[cpu].bctl;
@@ -369,7 +368,6 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 		__ASSERT(false, "invalid argument - unsupported power state");
 	}
 
-	(void)atomic_inc(&_cpus_idleing);
 	z_xt_ints_on(core_desc[cpu].intenable);
 }
 


### PR DESCRIPTION
This patch cleans-up and refactoring correct implementation of clock switching in idle thread.