### PR TITLE
[STABLE-v2.7] drivers: hda: insert an empty ";" statement before switch() labels

### DIFF
--- a/drivers/dma/dma_intel_adsp_hda.c
+++ b/drivers/dma/dma_intel_adsp_hda.c
@@ -181,8 +181,9 @@ int intel_adsp_hda_dma_host_reload(const struct device *dev, uint32_t channel,
 #endif
 	switch (cfg->direction) {
 	case HOST_TO_MEMORY:
-		uint32_t rp = *DGBRP(cfg->base, cfg->regblock_size, channel);
-		uint32_t next_rp = (rp + INTEL_HDA_MIN_FPI_INCREMENT_FOR_INTERRUPT) %
+		; /* Only statements can be labeled in C, a declaration is not valid */
+		const uint32_t rp = *DGBRP(cfg->base, cfg->regblock_size, channel);
+		const uint32_t next_rp = (rp + INTEL_HDA_MIN_FPI_INCREMENT_FOR_INTERRUPT) %
 			intel_adsp_hda_get_buffer_size(cfg->base, cfg->regblock_size, channel);
 
 		intel_adsp_hda_set_buffer_segment_ptr(cfg->base, cfg->regblock_size,
@@ -190,8 +191,9 @@ int intel_adsp_hda_dma_host_reload(const struct device *dev, uint32_t channel,
 		intel_adsp_hda_enable_buffer_interrupt(cfg->base, cfg->regblock_size, channel);
 		break;
 	case MEMORY_TO_HOST:
-		uint32_t wp = *DGBWP(cfg->base, cfg->regblock_size, channel);
-		uint32_t next_wp = (wp + INTEL_HDA_MIN_FPI_INCREMENT_FOR_INTERRUPT) %
+		;
+		const uint32_t wp = *DGBWP(cfg->base, cfg->regblock_size, channel);
+		const uint32_t next_wp = (wp + INTEL_HDA_MIN_FPI_INCREMENT_FOR_INTERRUPT) %
 			intel_adsp_hda_get_buffer_size(cfg->base, cfg->regblock_size, channel);
 
 		intel_adsp_hda_set_buffer_segment_ptr(cfg->base, cfg->regblock_size,


### PR DESCRIPTION
Only statements can be labeled in C, a declaration is not valid. This is an FAQ.

While compilers currently in use don't seem to care, the "sparse" static analyzer complains loudly (and cryptically):

https://github.com/thesofproject/sof/actions/runs/6052920348/job/16427323549

```
drivers/dma/dma_intel_adsp_hda.c:190:17: error: typename in expression
drivers/dma/dma_intel_adsp_hda.c:190:26: error: Expected ; at end of stmt
drivers/dma/dma_intel_adsp_hda.c:190:26: error: got rp
```

Add an empty ";" statement after each label makes `sparse` and probably others happy.

Also add missing `const` to constants for clarity.

Fixes commit a0263704619c ("drivers: hda: use interrupt for timing L1 exit on host DMA")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
(cherry picked from commit f0fd9f1713426397d120897d5aadb2456fc8e9d3)