### PR TITLE
[ptl-001-drop-stable] intel_adsp: clk: Configure correct cardinal clock divider for ACE3.0

### DIFF
--- a/soc/intel/intel_adsp/ace/include/ace30_ptl/adsp_shim.h
+++ b/soc/intel/intel_adsp/ace/include/ace30_ptl/adsp_shim.h
@@ -106,6 +106,9 @@ struct ace_dfpmccu {
 
 #define ACE_CLKCTL_WOVCRO    BIT(4)	  /* Request WOVCRO clock */
 
+#define ACE_CRODIV_CARCDS_MASK		GENMASK(7, 0)
+#define ACE_CRODIV_CARCDS(x)		((x) & ACE_CRODIV_CARCDS_MASK)
+
 #define SHIM_LDOCTL_HPSRAM_LDO_ON     (3 << 0)
 #define SHIM_LDOCTL_HPSRAM_LDO_BYPASS BIT(0)
 

--- a/soc/intel/intel_adsp/common/clk.c
+++ b/soc/intel/intel_adsp/common/clk.c
@@ -96,6 +96,11 @@ void adsp_clock_init(void)
 	} else {
 		platform_lowest_freq_idx = ADSP_CPU_CLOCK_FREQ_IPLL;
 	}
+#if CONFIG_SOC_INTEL_ACE30_PTL
+	/* Set the Cardinal clock divider to 18 to get 24.576MHz */
+	ACE_DfPMCCU.dfcrodiv &= ACE_CRODIV_CARCDS_MASK;
+	ACE_DfPMCCU.dfcrodiv |= ACE_CRODIV_CARCDS(0x12);
+#endif
 #else
 	CAVS_SHIM.clkctl |= CAVS_CLKCTL_WOVCRO;
 	if (CAVS_SHIM.clkctl & CAVS_CLKCTL_WOVCRO) {


### PR DESCRIPTION
Unlike previous platforms the Audio integration PLL is faster: 442.368 MHz instead 393.216 MHz.
The default divider of 16 will result incorrect cardinal clock speed. Change it to 18 for 24.576 MHz cardinal clock.